### PR TITLE
Fixed: Failed to construct 'URL': Invalid URL

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -38,6 +38,7 @@ const context = await esbuild.context({
 	sourcemap: prod ? false : "inline",
 	treeShaking: true,
 	outfile: "main.js",
+	platform: "node",
 });
 
 if (prod) {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,9 @@
 	},
 	"dependencies": {
 		"@types/lodash.pickby": "^4.6.9",
-		"https-proxy-agent": "^7.0.2",
 		"lodash.pickby": "^4.6.0",
 		"marked": "^11.1.0",
 		"svelte": "^4.2.8",
-		"ytdl-core": "^4.11.5"
+		"@distube/ytdl-core": "^4.15.8"
 	}
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,8 +3,7 @@ import { settingsStore } from './settings';
 import { get } from 'svelte/store';
 
 import fs from "fs";
-import ytdl from 'ytdl-core';
-import { HttpsProxyAgent } from 'https-proxy-agent';
+import ytdl from '@distube/ytdl-core';
 
 export default class ApiManager {
 	app: App;
@@ -34,7 +33,7 @@ export default class ApiManager {
 						stream = ytdl(videoUrl,{ quality: videores });
 					}
 				} else {
-					const agent = new HttpsProxyAgent(setings.ProxyIP);
+					const agent = ytdl.createProxyAgent({ uri: setings.ProxyIP });
 					if ( videores=== '' || videores === 'default') {
 						stream = ytdl(videoUrl, { requestOptions: { agent }, });
 					} else {

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,7 +25,6 @@ export default class ApiManager {
 			if (this.app.vault.adapter instanceof FileSystemAdapter) {
 				const fadp = this.app.vault.adapter;
 				const setings = get(settingsStore)
-				const agent = new HttpsProxyAgent(setings.ProxyIP);
 				let stream;
 				const  videores = setings.VideoResolution
 				if (setings.ProxyIP === "") {
@@ -35,6 +34,7 @@ export default class ApiManager {
 						stream = ytdl(videoUrl,{ quality: videores });
 					}
 				} else {
+					const agent = new HttpsProxyAgent(setings.ProxyIP);
 					if ( videores=== '' || videores === 'default') {
 						stream = ytdl(videoUrl, { requestOptions: { agent }, });
 					} else {

--- a/tests/downloaderYtber.js
+++ b/tests/downloaderYtber.js
@@ -1,9 +1,8 @@
 const fs = require('fs');
-const ytdl = require('ytdl-core');
-const {HttpsProxyAgent} = require('https-proxy-agent');
+const ytdl = require("@distube/ytdl-core");
 
 const proxy = 'http://127.0.0.1:7890';
-const agent = new HttpsProxyAgent(proxy);
+const agent = ytdl.createProxyAgent({ uri: proxy });
 const videoUrl = 'https://www.youtube.com/watch?v=aEOyEtArBI8'
 
 


### PR DESCRIPTION
- Still missing audio due to way YouTube keeps high resolution videos
- Sounds weird, but after node install there is need of manual change at `node_modules/tough-cookie/lib/cookie.js: Line 32`  for replacing `const punycode = require("punycode/");` to `const punycode = require("punycode");` , because `distube/ytdl-core` uses the `tough-cookie v4.1.4`, which have a typo in it 